### PR TITLE
Fix background-color for selects in dark mode

### DIFF
--- a/docs/assets/css/main2.scss
+++ b/docs/assets/css/main2.scss
@@ -24,5 +24,5 @@
   background-color: rgb(67, 64, 64);
 }
 #aw2-keyboard-layout {
-  background-color: "#000";
+  background-color: #000000;
 }


### PR DESCRIPTION
Colors in CSS don't have any quotes (`"`). Also I always recommended to use full length color names e.g. `#000000` instead of the short form `#000` as it causes less confusion.