### PR TITLE
Tag updates

### DIFF
--- a/docs/_posts/2022-03-29-li-mirage.md
+++ b/docs/_posts/2022-03-29-li-mirage.md
@@ -3,7 +3,7 @@ layout: build
 author: mukluk
 editor: berdandy
 title: Condi Mirage
-tags: condi mirage mesmer pof
+tags: condi mirage mesmer pof groupcontent
 tagline: "'I make a great army.'"
 spec: mirage
 ---

--- a/docs/_posts/2022-04-01-li-daredevil.md
+++ b/docs/_posts/2022-04-01-li-daredevil.md
@@ -3,7 +3,7 @@ layout: build
 author: mukluk
 editor: berdandy
 title: LI Daredevil
-tags: power thief daredevil hot
+tags: power thief daredevil hot groupcontent
 tagline: "This Daredevil build comes to you from Mukluk."
 excerpt: "This Daredevil build comes to you from Mukluk."
 spec: daredevil

--- a/docs/_posts/2022-04-07-boon-herald.md
+++ b/docs/_posts/2022-04-07-boon-herald.md
@@ -3,14 +3,16 @@ layout: build
 author: mukluk
 editor: berdandy
 title: Power Herald
-tags: power herald revenant hot
+tags: power herald revenant hot outdated
 tagline: "Shiny facets for fun and profit"
 spec: herald
 ---
 
 This Herald build uses glint's facets to keep boon uptime high without much stress.
 
-See video below for more details.
+See video below for more details. 
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Traits and Skills
 

--- a/docs/_posts/2022-04-10-li-soulbeast.md
+++ b/docs/_posts/2022-04-10-li-soulbeast.md
@@ -3,7 +3,7 @@ layout: build
 author: mukluk
 editor: berdandy
 title: LI Shortbow Soulbeast
-tags: condi ranger soulbeast pof
+tags: condi ranger soulbeast pof groupcontent
 tagline: "'I know animals more gallant than the African warthog, but none more courageous [...] His eyes are small and lightless and capable of but one expression - suspicion. What he does not understand, he suspects, and what he suspects, he fights.'<br/>-- Beryl Markham"
 spec: soulbeast
 ---
@@ -89,8 +89,6 @@ Pet
 - Shortbow Earth/Bursting
 
 ## Notes and Tips
-
-If running with a group and can accomodate another keypress, consider swapping Signet of the Wild for either Sun Spirit (Power group) or Frost Spirit (Condi group) to buff everyone's damage.
 
 Elite skills are flexible and not particularly effective in this build. Generally choose Strength of the Pack (useful if alone), or Entangle for a bit of extra dps.
 

--- a/docs/_posts/2022-04-12-power-dragonhunter.md
+++ b/docs/_posts/2022-04-12-power-dragonhunter.md
@@ -3,12 +3,14 @@ layout: build
 author: jupiter
 editor: berdandy
 title: Power Dragonhunter
-tags: power guardian dragonhunter hot
+tags: power guardian dragonhunter hot outdated
 tagline: "We men dream dreams, we work magic, we do good, we do evil. The dragons do not dream. They are dreams. They do not work magic: it is their substance, their being. They do not do; they are."
 spec: dragonhunter
 ---
 
 This moderate intensity Dragonhunter build stays in melee distance and uses the strong sustain of dragonhunter skills to good effect.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Tier Notes
 

--- a/docs/_posts/2022-04-14-li-reaper.md
+++ b/docs/_posts/2022-04-14-li-reaper.md
@@ -3,12 +3,14 @@ layout: build
 author: mukluk
 editor: berdandy
 title: LI Reaper
-tags: power necromancer reaper hot 
+tags: power necromancer reaper hot outdated
 tagline: "Come to the dark side. We have cookies."
 spec: reaper
 ---
 
 This signet and minion Reaper build prioritizes shroud damage and life force generation.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Tier Notes
 

--- a/docs/_posts/2022-04-19-power-bladesworn.md
+++ b/docs/_posts/2022-04-19-power-bladesworn.md
@@ -2,7 +2,7 @@
 layout: build
 author: muwum
 title: Power Bladesworn
-tags: power warrior bladesworn eod
+tags: power warrior bladesworn eod groupcontent
 tagline: "'It is my duty to keep the people of Cantha safe.'<br/>-- Minister Li"
 spec: bladesworn
 ---

--- a/docs/_posts/2022-04-21-li-willbender.md
+++ b/docs/_posts/2022-04-21-li-willbender.md
@@ -3,12 +3,14 @@ layout: build
 author: mukluk
 editor: berdandy
 title: LI Willbender
-tags: condi guardian willbender eod
+tags: condi guardian willbender eod groupcontent
 tagline: "Blue flames burn hotter"
 spec: willbender
 ---
 
 Mukluk released another LI build, this time for the new Guardian EoD specialization, the Willbender.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 _Note: I'll do a better write-up later when I have spoons, but the build is provided below. Rotation notes can be found in the video below the build_
 

--- a/docs/_posts/2022-04-28-li-burst-god-holosmith.md
+++ b/docs/_posts/2022-04-28-li-burst-god-holosmith.md
@@ -3,7 +3,7 @@ layout: build
 author: mrmystic
 editor: zrtassassin
 title: Burst God Holosmith
-tags: power engineer holosmith pof
+tags: power engineer holosmith pof groupcontent
 tagline: "Auto to victory!"
 spec: holosmith
 ---

--- a/docs/_posts/2022-04-29-heal-chonomancer.md
+++ b/docs/_posts/2022-04-29-heal-chonomancer.md
@@ -2,12 +2,14 @@
 layout: build
 author: muwum
 title: Heal Chronomancer
-tags: healing mesmer chronomancer hot
+tags: healing mesmer chronomancer hot groupcontent
 tagline: "'Laugh, my friend, for in your actions you have at last seen behind the mask.'<br/>-- Keeper of Illusion"
 spec: chronomancer
 ---
 
 This Heal Chronomancer Mesmer build averages at about 12 APM. This is a build based on wells, making movement control a potential factor.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Tier Notes
 

--- a/docs/_posts/2022-06-05-HSAC-Elementalist-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Elementalist-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: Locogeke.2537
 editor: berdandy
 title: Elementalist - DPS
-tags: elementalist dps tempest hsac condi
+tags: condi elementalist tempest hot hsac groupcontent
 spec: tempest
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Elementalist-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Elementalist-Best-Support.md
@@ -2,7 +2,7 @@
 credit: Jzaku.9765
 editor: berdandy
 title: Elementalist - Support
-tags: elementalist support tempest hsac
+tags: healing elementalist tempest hot hsac groupcontent
 spec: tempest
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Elementalist-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Elementalist-Most-Creative.md
@@ -2,13 +2,15 @@
 credit: Micro Hard.3601
 editor: berdandy
 title: Elementalist - Creative
-tags: elementalist support catalyst hsac
+tags: support power elementalist catalyst eod hsac groupcontent outdated
 spec: catalyst
 tagline: Hardstuck Accessibility Challenge
 ---
 
 20k dps D/D Quickness Catalyst. Build provides 25might, fury, quickness, prot, and high resistance. Can trade prot and resistance for vigor and resolution by swapping to water instead of earth in the rotation.
 Exchanging the fire traitline for arcane with the same rotation provides identical 20k dps in addition to having higher boon duration and the revive trait; however, the fire traitline has the potential to do more dps with additional apm, but that would exceed the requirements.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Gear
 

--- a/docs/_posts/2022-06-05-HSAC-Engineer-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Engineer-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: Thor.3267
 editor: berdandy
 title: Engineer - DPS
-tags: engineer dps mechanist condi hsac
+tags: condi engineer mechanist eod hsac groupcontent
 spec: mechanist
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Engineer-Best-Support-Mechanist.md
+++ b/docs/_posts/2022-06-05-HSAC-Engineer-Best-Support-Mechanist.md
@@ -1,15 +1,15 @@
 ---
 credit: Sutepun.9450
 editor: berdandy
-title: Engineer - Support
-tags: engineer support hsac scrapper
+title: Engineer - Support Alacrity
+tags: support engineer mechanist eod hsac groupcontent
 spec: scrapper
 tagline: Hardstuck Accessibility Challenge
 ---
 
-An engineer loadout that compresses two DPS support builds with only one equipment template. This allows for a player to easily swap between the two without sacrificing their "main" engineer build.
+An engineer loadout that compresses two DPS support builds with only one equipment template. This allows for a player to easily swap between the two without sacrificing their "main" engineer build. Alacrity Version.
 
-_[Editor's Note: only one gw2skills link was provided, perhaps the "two DPS support builds" are shown in the videos provided to the hardstuck challenge?]_
+_[Editor's Note: The Engineer - Best Support winner has 2 builds using the same equipment and different elite specialisations for providing Quickness or Alacrity and was split into 2 builds here.]_
 
 ## Gear
 
@@ -36,7 +36,7 @@ Template Code:
   data-armory-ids='6,38,43'
   data-armory-6-traits='1882,1892,1947'
   data-armory-38-traits='1914,1923,526'
-  data-armory-43-traits='1917,1860,2052'
+  data-armory-70-traits='2296,2276,2281'
 >
 </div>
 <script async src='https://unpkg.com/armory-embeds@^0.x.x/armory-embeds.js'></script>
@@ -45,4 +45,5 @@ Template Code:
 
 ## References
 
-- [Gw2Skills](http://gw2skills.net/editor/?PeQAQlRw4YNMI2JO2LvtWA-zRZYBRBtaLIC4QUtHGRJQVBoOLjqsB-e)
+- [Youtube](https://www.youtube.com/watch?v=Mbo91IVHvNo)
+- [Gw2Skills](http://en.gw2skills.net/editor/?PeQAQlxy4YusXWMO2LvRVA-zRZYBRBtaLIC4QUtHGRJQVBoeQCgNAWGVbD-e)

--- a/docs/_posts/2022-06-05-HSAC-Engineer-Best-Support-Scrapper.md
+++ b/docs/_posts/2022-06-05-HSAC-Engineer-Best-Support-Scrapper.md
@@ -1,0 +1,49 @@
+---
+credit: Sutepun.9450
+editor: berdandy
+title: Engineer - Support Quickness
+tags: support engineer scrapper hot hsac groupcontent
+spec: scrapper
+tagline: Hardstuck Accessibility Challenge
+---
+
+An engineer loadout that compresses two DPS support builds with only one equipment template. This allows for a player to easily swap between the two without sacrificing their "main" engineer build. Quickness Version.
+
+_[Editor's Note: The Engineer - Best Support winner has 2 builds using the same equipment and different elite specialisations for providing Quickness or Alacrity and was split into 2 builds here.]_
+
+## Gear
+
+- Weapons: Berserker Rifle with Force/Accuracy Sigils
+- Armor: Diviner Leggings, and the rest Berserker, all with Strength Runes
+- Trinkets: One Assassin Ring, and the rest Diviner
+- Food & Utility: Bowl of Curry Butternut Squash Soup, Tin of Fruitcake
+
+## Traits and Skills
+
+Template Code:
+
+`[&DQMGOyYvKy3ZEgAABwEAACcTAACuEgAAgxIAAAAAAAAAAAAAAAAAAAAAAAA=]`
+
+---
+
+<div
+  data-armory-embed='skills'
+  data-armory-ids='30357,5812,31248,29921,30815'
+>
+</div>
+<div
+  data-armory-embed='specializations'
+  data-armory-ids='6,38,43'
+  data-armory-6-traits='1882,1892,1947'
+  data-armory-38-traits='1914,1923,526'
+  data-armory-43-traits='1917,1860,2052'
+>
+</div>
+<script async src='https://unpkg.com/armory-embeds@^0.x.x/armory-embeds.js'></script>
+
+
+
+## References
+
+- [Youtube](https://www.youtube.com/watch?v=Mbo91IVHvNo)
+- [Gw2Skills](http://gw2skills.net/editor/?PeQAQlRw4YNMI2JO2LvtWA-zRZYBRBtaLIC4QUtHGRJQVBoOLjqsB-e)

--- a/docs/_posts/2022-06-05-HSAC-Engineer-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Engineer-Most-Creative.md
@@ -2,7 +2,7 @@
 credit: Xyonon.3987
 editor: berdandy
 title: Engineer - Creative
-tags: engineer dps hsac mechanist
+tags: power engineer mechanist eod hsac groupcontent
 spec: mechanist
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Engineer-Wildcard.md
+++ b/docs/_posts/2022-06-05-HSAC-Engineer-Wildcard.md
@@ -2,7 +2,7 @@
 credit: asterius.3941
 editor: berdandy
 title: Engineer - Wildcard
-tags: engineer dps hsac condi mechanist
+tags: condi engineer mechanist eod hsac groupcontent
 spec: mechanist
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Guardian-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Guardian-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: supporthero.4520
 editor: berdandy
 title: Guardian - DPS
-tags: guardian dps hsac firebrand
+tags: condi guardian firebrand pof hsac groupcontent
 spec: firebrand
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Guardian-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Guardian-Best-Support.md
@@ -2,7 +2,7 @@
 credit: Bovan.9481
 editor: berdandy
 title: Guardian - Support
-tags: guardian support hsac firebrand
+tags: healing support guardian firebrand pof hsac groupcontent
 spec: firebrand
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Guardian-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Guardian-Most-Creative.md
@@ -2,7 +2,7 @@
 credit: Sayrann.1356
 editor: berdandy
 title: Guardian - Creative
-tags: guardian dps hsac dragonhunter
+tags: power guardian dragonhunter hot hsac groupcontent
 spec: dragonhunter
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: ntiCe.9071
 editor: berdandy
 title: Mesmer - DPS
-tags: mesmer dps hsac mirage
+tags: condi mesmer mirage pof hsac groupcontent
 spec: mirage
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Best-Support.md
@@ -2,12 +2,14 @@
 credit: gewoonreneee.2967
 editor: berdandy
 title: Mesmer - Support
-tags: mesmer support chronomancer hsac
+tags: support mesmer chronomancer hot hsac groupcontent outdated
 spec: chronomancer
 tagline: Hardstuck Accessibility Challenge
 ---
 
 Chrono tank build providing quickness and alacrity, and helping the druid's with a place in the meta.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Gear
 

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Most-Creative.md
@@ -2,7 +2,7 @@
 credit: REMagic.8937
 editor: berdandy
 title: Mesmer - Creative
-tags: mesmer dps mirage hsac
+tags: condi mesmer mirage pof hsac groupcontent
 spec: mirage
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard.md
@@ -2,7 +2,7 @@
 credit: rekinetics.6183
 editor: berdandy
 title: Mesmer - Wildcard
-tags: mesmer dps virtuoso hsac
+tags: condi mesmer virtuoso eod hsac
 spec: virtuoso
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt.md
@@ -2,10 +2,12 @@
 credit: Awesumness.1823
 editor: berdandy
 title: Mesmer - Wildcard
-tags: mesmer dps virtuoso hsac
+tags: condi mesmer virtuoso eod hsac groupcontent
 spec: virtuoso
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 This build focuses on ease of play and scalability with the APM of the player
 

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt_Alt.md
@@ -2,12 +2,14 @@
 credit: Kauna Arget.7052
 editor: berdandy
 title: Mesmer - Wildcard
-tags: mesmer dps condi virtuoso hsac
+tags: condi mesmer virtuoso eod hsac groupcontent
 spec: virtuoso
 tagline: Hardstuck Accessibility Challenge
 ---
 
 Condition Virtuoso - will do 25k with 2 buttons, has a free utility slot, does own stability and can be used to black kite and pylon in raids.
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Gear
 

--- a/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt_Alt_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Mesmer-Wildcard_Alt_Alt_Alt.md
@@ -2,7 +2,7 @@
 credit: Kirby.7302
 editor: berdandy
 title: Mesmer - Wildcard
-tags: mesmer support mirage hsac
+tags: support condi mesmer mirage pof hsac groupcontent
 spec: mirage
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Necromancer-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Necromancer-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: Micro Hard.3601
 editor: berdandy
 title: Necromancer - DPS
-tags: necromancer dps harbinger hsac
+tags: condi necromancer harbinger eod hsac groupcontent
 spec: harbinger
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Necromancer-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Necromancer-Best-Support.md
@@ -2,7 +2,7 @@
 credit: Angrax.9420
 editor: berdandy
 title: Necromancer - Support
-tags: necromancer support harbinger hsac
+tags: support healing necromancer harbinger eod hsac groupcontent
 spec: harbinger
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Necromancer-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Necromancer-Most-Creative.md
@@ -2,7 +2,7 @@
 credit: lcpdragonslayer.7895
 editor: berdandy
 title: Necromancer - Creative
-tags: necromancer dps harbinger hsac
+tags: condi necromancer harbinger eod hsac
 spec: harbinger
 tagline: Hardstuck Accessibility Challenge
 ---
@@ -11,7 +11,10 @@ tagline: Hardstuck Accessibility Challenge
 
 ## Gear
 
-_[Editor's Note: Gear was not provided. Good luck!]_
+- Weapons: Ritualist Pistol/Dagger with Bursting/Torment Sigils
+- Armor: Viper with Tormenting Runes
+- Trinkets: Viper
+- Food & Utility: Plate of Beef Rendang, Tuning Icicle
 
 ## Traits and Skills
 
@@ -40,4 +43,5 @@ Template Code:
 
 ## References
 
+- [Youtube](https://www.youtube.com/watch?v=cvffhAEi4qw)
 - [Imgur Screenshot](https://i.imgur.com/r36zHT1.png)

--- a/docs/_posts/2022-06-05-HSAC-Necromancer-Wildcard.md
+++ b/docs/_posts/2022-06-05-HSAC-Necromancer-Wildcard.md
@@ -2,10 +2,12 @@
 credit: Dreggon.6598
 editor: berdandy
 title: Necromancer - Wildcard
-tags: necromancer reaper hsac
+tags: power necromancer reaper hot hsac outdated
 spec: reaper
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 Solo signet reaper build for open world, designed to go into shroud and STAY THERE. Pulls about 15-17k on a golem without any external buffs, solos a few champs (e.g. guild missions) but not all of them, sustains LONG periods of shroud thanks to signet of undeath, and has a 99% crit chance while in shroud - and you always want to be in shroud, because that's where your damage is. Takes out groups fast and easy, has two health bars to stay alive, uses a cleansing sigil on the axe swap. Build has no stun break, or condi cleanse outside of cleansing sigil
 

--- a/docs/_posts/2022-06-05-HSAC-Necromancer-Wildcard_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Necromancer-Wildcard_Alt.md
@@ -2,7 +2,7 @@
 credit: Katastroff.1045 
 editor: berdandy
 title: Necromancer - Wildcard
-tags: necromancer reaper hsac
+tags: power necromancer reaper hot hsac
 spec: reaper
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Ranger-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Ranger-Best-DPS.md
@@ -2,12 +2,14 @@
 credit: GoE
 editor: berdandy
 title: Ranger - DPS
-tags: ranger dps soulbeast hsac
+tags: power ranger soulbeast pof hsac groupcontent outdated
 spec: soulbeast
 tagline: Hardstuck Accessibility Challenge
 ---
 
 A low apm power soulbeast build providing minor group support with spirits, stance share and the versatility of ranger pets
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Gear
 

--- a/docs/_posts/2022-06-05-HSAC-Ranger-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Ranger-Best-Support.md
@@ -2,12 +2,14 @@
 credit: GoE
 editor: berdandy
 title: Ranger - Support
-tags: ranger support hsac soulbeast
+tags: condi ranger soulbeast pof hsac groupcontent outdated
 spec: soulbeast
 tagline: Hardstuck Accessibility Challenge
 ---
 
 A low apm condi soulbeast build providing minor support and utility through spirits, stance share, a fast high cc skill and the versatility of ranger pets
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 ## Gear
 

--- a/docs/_posts/2022-06-05-HSAC-Ranger-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Ranger-Most-Creative.md
@@ -2,10 +2,12 @@
 credit: Sayrann.1356
 editor: berdandy
 title: Ranger - Creative
-tags: ranger support soulbeast hsac
+tags: condi ranger soulbeast pof hsac groupcontent outdated
 spec: soulbeast
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 It's a condition dps support Soulbeast which deals good DPS, supports your allies via stances and spirits and has good utility for itself
 

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: Ziooo.8932
 editor: berdandy
 title: Revenant - DPS
-tags: revenant dps vindicator hsac
+tags: power revenant vindicator eod hsac groupcontent
 spec: vindicator
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Best-Support.md
@@ -2,10 +2,12 @@
 credit: Hysvear.7386
 editor: berdandy
 title: Revenant - Support
-tags: revenant support herald hsac
+tags: healing revenant herald hot hsac groupcontent outdated
 spec: herald
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, healing and utility may be different now.
 
 The "Herald of Life" build is a Revenant Elite spec build that provides. It pulses Alacrity, Healing, Regen, Protection, Fury, Might, and did I mention healing? It also provides CC options and it has quite a bit of toughness and about 25k health.
 (Dodging? pshh who needs it.

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Most-Creative.md
@@ -2,10 +2,12 @@
 credit: Waldorn.5643
 editor: berdandy
 title: Revenant - Creative
-tags: revenant support herald hsac
+tags: healing revenant herald hot hsac groupcontent outdated
 spec: herald
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, healing and utility may be different now.
 
 The Heal Herald
 

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard.md
@@ -2,7 +2,7 @@
 credit: Waldorn.5643
 editor: berdandy
 title: Revenant - Wildcard
-tags: revenant dps herald hsac
+tags: power revenant herald hot hsac groupcontent
 spec: herald
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard_Alt.md
@@ -2,10 +2,12 @@
 credit: Ebax.1320
 editor: berdandy
 title: Revenant - Wildcard
-tags: revenant support vindicator hsac
+tags: healing revenant vindicator eod hsac groupcontent outdated
 spec: vindicator
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, healing and utility may be different now.
 
 Vindicator has the potential for some absurd healing per second (like 2k per second per player) with just holding up the urn of saint viktor. The self-damaging effect from the urn can be completely negated with the salvation trait "Resilient Spirit" which gives barrier per boon on you every 3 seconds (to a cap of 5 boons). By keeping your vitality low, you minimize the amount of self-damage the urn does to the point that having 4 boons will make it so you can hold up the urn forever
 

--- a/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard_Alt_Alt.md
+++ b/docs/_posts/2022-06-05-HSAC-Revenant-Wildcard_Alt_Alt.md
@@ -2,10 +2,12 @@
 credit: Douwe.1746
 editor: berdandy
 title: Revenant - Wildcard 
-tags: revenant herald hsac
+tags: revenant herald hot hsac
 spec: herald
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 Farming mobs from the Halloween Labyrinth and similair events are always a bit stressfull and intense for me, while it should be relaxing. So I figured out a way to maximize loot while minimizing stress
 By using Revenants unique aoe upkeep skills and with a few smart gear choices it is possible to have cheap, yet effective, mob farmer

--- a/docs/_posts/2022-06-05-HSAC-Thief-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Thief-Best-DPS.md
@@ -2,7 +2,7 @@
 credit: GoE
 editor: berdandy
 title: Thief - DPS
-tags: thief dps condi hsac
+tags: condi thief core hsac groupcontent
 spec: thief
 tagline: Hardstuck Accessibility Challenge
 ---

--- a/docs/_posts/2022-06-05-HSAC-Thief-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Thief-Best-Support.md
@@ -2,10 +2,12 @@
 credit: rekinetics.6183
 editor: berdandy
 title: Thief - Support
-tags: thief support specter hsac
+tags: healing support thief specter eod hsac groupcontent outdated
 spec: specter
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, healing and utility may be different now.
 
 Healing Alacrity Specter!
 

--- a/docs/_posts/2022-06-05-HSAC-Thief-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Thief-Most-Creative.md
@@ -2,10 +2,12 @@
 credit: Bovan.9481
 editor: berdandy
 title: Thief - Creative
-tags: thief support specter hsac
+tags: healing support thief specter eod hsac groupcontent outdated
 spec: specter
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, healing and utility may be different now.
 
 There is a lot to talk about but I'll do my best to keep it short.
 

--- a/docs/_posts/2022-06-05-HSAC-Warrior-Best-DPS.md
+++ b/docs/_posts/2022-06-05-HSAC-Warrior-Best-DPS.md
@@ -2,10 +2,12 @@
 credit: Micro Hard.3601
 editor: berdandy
 title: Warrior - DPS
-tags: warrior dps bladesworn hsac
+tags: power warrior bladesworn eod hsac groupcontent outdated
 spec: bladesworn
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 Standard dps role as a Blade Sworn pulling 31k dps. Uses Flow Stabilizer for QoL whenever Flow is needed, but can get away without taking it.
 

--- a/docs/_posts/2022-06-05-HSAC-Warrior-Best-Support.md
+++ b/docs/_posts/2022-06-05-HSAC-Warrior-Best-Support.md
@@ -2,10 +2,12 @@
 credit: Narcin Roc.3018
 editor: berdandy
 title: Warrior - Support
-tags: warrior support hsac
+tags: power warrior core hsac groupcontent outdated
 spec: warrior
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 Low Intensity Banner Friend
 

--- a/docs/_posts/2022-06-05-HSAC-Warrior-Most-Creative.md
+++ b/docs/_posts/2022-06-05-HSAC-Warrior-Most-Creative.md
@@ -2,10 +2,12 @@
 credit: Spyritdragon.6048
 editor: berdandy
 title: Warrior - Creative
-tags: warrior dps berserker hsac
+tags: power warrior berserker hot hsac groupcontent outdated
 spec: berserker
 tagline: Hardstuck Accessibility Challenge
 ---
+
+Several traits and skills have changed since this build was published, damage and utility may be different now.
 
 An APM-scaling variant of the standard power banner Berserker build that offers a solid and extremely simple baseline for people to follow, and then move on from there as fits their own comfort level.
 


### PR DESCRIPTION
Updated all build tags to show the following information:

- build is `condi`, `power`, `healing` or `support`, with `support` indicating builds able to provide quickness or alacrity to a subgroup
- core and elite spec, as well as needed expansion
- whether the build is from the Hardstuck Accessibility Competition (`hsac`)
- whether the build is aimed to be used in organised `groupcontent`
- whether the build is `outdated` due to the June 28th 2022 balance patch

Builds stating DPS or support capabilities changed in the last balance patch also got a note mentioning that they may be different now.

--

This also contains 2 changes to hsac builds: 
- the Support Engineer build was split into 2 separate builds
- added gear information and Youtube link to the Creative Necromancer build